### PR TITLE
Typo on bootstrap version

### DIFF
--- a/snippets/9.20.html
+++ b/snippets/9.20.html
@@ -1,4 +1,4 @@
 <link
     rel="stylesheet"
-    href="https://stackpath.bootstrapcdn.com/bootstrap/4.4.1/css/bootstrap.css"
+    href="https://stackpath.bootstrapcdn.com/bootstrap/4.5.0/css/bootstrap.css"
 >


### PR DESCRIPTION
Fix to be compatible with https://github.com/handsonscala/handsonscala/blob/v1/snippets/9.21.scala