### PR TITLE
Update GitHub API URL

### DIFF
--- a/examples/7.8 - StreamingDownloadProcessReuploadTee/StreamingDownloadProcessReupload.sc
+++ b/examples/7.8 - StreamingDownloadProcessReuploadTee/StreamingDownloadProcessReupload.sc
@@ -1,4 +1,4 @@
-val download = os.proc( "curl", "https://api.github.com/repos/lihaoyi/mill/releases").spawn()
+val download = os.proc( "curl", "https://api.github.com/repositories/107214500/releases").spawn()
 val base64 = os.proc("base64").spawn(stdin = download.stdout)
 val gzip = os.proc("gzip").spawn(stdin = base64.stdout)
 val tee = os.proc("tee", "base64.gz").spawn(stdin = gzip.stdout)


### PR DESCRIPTION
Because of changes to GitHub's API, the current URL doesn't quite work, but the provided one outputs the desired data.